### PR TITLE
add simple twitch auth documentation

### DIFF
--- a/auth.md
+++ b/auth.md
@@ -1,0 +1,6 @@
+# Auth
+
+- Create an Application on: https://dev.twitch.tv/console/apps/create (tip: don`t use the name twitch on your app name)
+- http://localhost:18297 is the OAuth Redirect URL
+- Generate a secret
+- Put all values into auth.txt


### PR DESCRIPTION
I never did a Twitch integration. So I added a simple markdown file to help other developers creating the twitch credentials, without digging trough the Twitch documentation.