### PR TITLE
list of waiting and dead viewers

### DIFF
--- a/scenes/games/pool_royale/pool_royale.tscn
+++ b/scenes/games/pool_royale/pool_royale.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=3 uid="uid://c75i61yyvkd1e"]
+[gd_scene load_steps=14 format=3 uid="uid://c75i61yyvkd1e"]
 
 [ext_resource type="Script" path="res://scenes/games/pool_royale/scripts/pool_royale.gd" id="1_x1ler"]
 [ext_resource type="FontFile" uid="uid://dd1r2fwpg8dya" path="res://shared/fonts/MPLUSCodeLatin-Medium.ttf" id="2_87d87"]
@@ -7,6 +7,7 @@
 [ext_resource type="PackedScene" uid="uid://cowkp06pmwewa" path="res://scenes/games/pool_royale/bumper.tscn" id="3_x2hen"]
 [ext_resource type="Script" path="res://scenes/games/cannon/countdown.gd" id="4_ilfop"]
 [ext_resource type="PackedScene" uid="uid://c8bdqqhg6e1u8" path="res://scenes/games/pool_royale/moving_object.tscn" id="6_5228q"]
+[ext_resource type="PackedScene" uid="uid://d1ktqkqvqmhyd" path="res://scenes/ui/viewers_list.tscn" id="8_3hiv4"]
 
 [sub_resource type="Gradient" id="Gradient_131dc"]
 offsets = PackedFloat32Array(0.163347, 0.860558)
@@ -257,6 +258,7 @@ text = "Winner:"
 horizontal_alignment = 1
 
 [node name="Countdown" type="Label" parent="CanvasLayer"]
+visible = false
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
@@ -285,6 +287,45 @@ offset_left = -801.0
 offset_top = -527.0
 offset_right = 1667.0
 offset_bottom = 876.0
+
+[node name="WaitingList" type="VBoxContainer" parent="CanvasLayer"]
+offset_left = 1612.0
+offset_top = 72.0
+offset_right = 1853.0
+offset_bottom = 1009.0
+
+[node name="Label" type="Label" parent="CanvasLayer/WaitingList"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 20
+text = "Waiting"
+horizontal_alignment = 2
+
+[node name="ViewersList" parent="CanvasLayer/WaitingList" instance=ExtResource("8_3hiv4")]
+layout_direction = 3
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 0.447059)
+theme_override_colors/guide_color = Color(0, 0, 0, 0)
+theme_override_font_sizes/font_size = 16
+allow_search = false
+
+[node name="DeadList" type="VBoxContainer" parent="CanvasLayer"]
+offset_left = 68.0
+offset_top = 68.0
+offset_right = 309.0
+offset_bottom = 1005.0
+
+[node name="Label" type="Label" parent="CanvasLayer/DeadList"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 20
+text = "Dead"
+
+[node name="ViewersList" parent="CanvasLayer/DeadList" instance=ExtResource("8_3hiv4")]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 0.447059)
+theme_override_colors/guide_color = Color(0, 0, 0, 0)
+theme_override_font_sizes/font_size = 16
+allow_search = false
+list_type = 2
 
 [connection signal="body_entered" from="DeathArea" to="." method="_on_death_area_body_entered"]
 [connection signal="finished" from="CanvasLayer/Countdown" to="." method="_on_countdown_finished"]

--- a/scenes/games/pool_royale/scripts/pool_royale.gd
+++ b/scenes/games/pool_royale/scripts/pool_royale.gd
@@ -12,6 +12,8 @@ var state: GAME_STATE = GAME_STATE.WAITING
 @onready var waiting: Label = $CanvasLayer/Waiting
 @onready var countdown: Label = $CanvasLayer/Countdown
 @onready var winner: Label = $CanvasLayer/Winner
+@onready var waiting_list: VBoxContainer = $CanvasLayer/WaitingList
+@onready var dead_list: VBoxContainer = $CanvasLayer/DeadList
 
 var viewer_avatars: Dictionary = {}
 
@@ -53,23 +55,31 @@ func change_state(new_state: GAME_STATE) -> void:
 			prints("GAME_STATE.WAITING")
 			waiting.visible = true
 			winner.visible = false
+			waiting_list.visible = false
+			dead_list.visible = false
 			Viewers.open()
 			Viewers.unlock_active()
 		GAME_STATE.RUNNING:
 			prints("GAME_STATE.RUNNING")
 			waiting.visible = false
 			winner.visible = false
+			waiting_list.visible = true
+			dead_list.visible = true
 			Viewers.lock_active()
 		GAME_STATE.WINNER:
 			prints("GAME_STATE.WINNER")
 			waiting.visible = false
 			winner.visible = true
+			waiting_list.visible = true
+			dead_list.visible = true
 			Viewers.lock_active()
 			Viewers.wait_all()
 		GAME_STATE.PAUSED:
 			prints("GAME_STATE.PAUSED")
 			waiting.visible = false
 			winner.visible = false
+			waiting_list.visible = false
+			dead_list.visible = false
 			Viewers.lock_active()
 
 func fire_viewer(viewer_name: String, angle: float, power: float) -> void:

--- a/scenes/ui/scripts/viewers_list.gd
+++ b/scenes/ui/scripts/viewers_list.gd
@@ -1,0 +1,62 @@
+extends ItemList
+
+enum TYPE { ACTIVE, WAITING, DEAD }
+
+
+@export var list_type:TYPE = TYPE.WAITING
+
+func _ready() -> void:
+	clear()
+
+	if !Viewers:
+		return
+
+	if list_type == TYPE.WAITING:
+		for viewer in Viewers.viewers_waiting:
+			add_item(viewer)
+
+		Viewers.viewer_waiting.connect(on_add_waiting)
+		Viewers.viewer_active.connect(on_remove_waiting)
+		Viewers.viewer_dead.connect(on_remove_waiting)
+
+	elif list_type == TYPE.ACTIVE:
+		for viewer in Viewers.viewers_active:
+			add_item(viewer)
+
+		Viewers.viewer_waiting.connect(on_remove_waiting)
+		Viewers.viewer_active.connect(on_add_waiting)
+		Viewers.viewer_dead.connect(on_remove_waiting)
+
+	elif list_type == TYPE.DEAD:
+		for viewer in Viewers.viewers_dead:
+			add_item(viewer)
+
+		Viewers.viewer_waiting.connect(on_remove_waiting)
+		Viewers.viewer_active.connect(on_remove_waiting)
+		Viewers.viewer_dead.connect(on_add_waiting)
+
+	Viewers.viewer_removed.connect(on_remove_waiting)
+
+
+func on_add_waiting(viewer_name: String) -> void:
+	if get_viewer_idx(viewer_name) > -1:
+		return
+
+	add_item(viewer_name)
+
+
+func on_remove_waiting(viewer_name: String) -> void:
+	var index: int = get_viewer_idx(viewer_name)
+
+	if index == -1:
+		return
+
+	remove_item(index)
+
+
+func get_viewer_idx(viewer_name: String) -> int:
+	for i in get_item_count():
+		if get_item_text(i) == viewer_name:
+			return i
+
+	return -1

--- a/scenes/ui/viewers_list.tscn
+++ b/scenes/ui/viewers_list.tscn
@@ -1,0 +1,20 @@
+[gd_scene load_steps=3 format=3 uid="uid://d1ktqkqvqmhyd"]
+
+[ext_resource type="Script" path="res://scenes/ui/scripts/viewers_list.gd" id="1_c80a8"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_2m381"]
+
+[node name="ViewersList" type="ItemList"]
+custom_minimum_size = Vector2(50, 50)
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxEmpty_2m381")
+auto_height = true
+item_count = 2
+item_0/text = "test_viewer"
+item_0/selectable = false
+item_1/text = "viewer_1"
+script = ExtResource("1_c80a8")


### PR DESCRIPTION
closes #59

- added a simple scene that can track states of viewers
- uses the viewers class
- display states: 
   - `waiting`
   - `active`
   - `dead`
- example implementation in `pool_royale`
- has only basic styling