### PR TITLE
refactor gift singleton to handle commands better

### DIFF
--- a/scenes/games/cannon/cannon.gd
+++ b/scenes/games/cannon/cannon.gd
@@ -27,11 +27,13 @@ func _ready() -> void:
 	GiftSingleton.viewer_joined.connect(on_viewer_joined)
 	GiftSingleton.viewer_left.connect(on_viewer_left)
 	GiftSingleton.user_left_chat.connect(on_viewer_left_chat)
-	# Command: !fire 90
-	GiftSingleton.add_command("fire", on_viewer_fire, 2, 2)
 
-	GiftSingleton.add_command("start", on_streamer_start, 1, 1, GiftSingleton.PermissionFlag.STREAMER)
-	GiftSingleton.add_command("wait", on_streamer_wait, 0, 0, GiftSingleton.PermissionFlag.STREAMER)
+	# Command: !fire 90 100
+	GiftSingleton.add_game_command("fire", on_viewer_fire, 2, 2)
+	GiftSingleton.add_alias("fire", "f")
+
+	GiftSingleton.streamer_start.connect(on_streamer_start)
+	GiftSingleton.streamer_wait.connect(on_streamer_wait)
 
 	SignalBus.transparency_toggled.connect(on_transparency_toggled)
 
@@ -151,7 +153,7 @@ func on_viewer_fire(cmd_info : CommandInfo, arg_arr : PackedStringArray) -> void
 	var power: float = float(arg_arr[1])
 	fire_viewer(cmd_info.sender_data.tags["display-name"], angle, power)
 
-func on_streamer_start(cmd_info : CommandInfo, arg_arr : PackedStringArray) -> void:
+func on_streamer_start(arg_arr : PackedStringArray) -> void:
 	var countdown_duration: float = default_countdown
 	if not arg_arr.is_empty():
 		if arg_arr[0].is_valid_float():

--- a/scenes/games/numbermind/scripts/numbermind.gd
+++ b/scenes/games/numbermind/scripts/numbermind.gd
@@ -10,7 +10,7 @@ var active: bool = false
 func _ready():
 	GameConfigManager.load_config()
 
-	GiftSingleton.add_command("guess", on_guess_made, 1, 1)
+	GiftSingleton.add_game_command("guess", on_guess_made, 1, 1)
 
 	SignalBus.transparency_toggled.connect(on_transparency_toggled)
 

--- a/scenes/games/pool_royale/scripts/pool_royale.gd
+++ b/scenes/games/pool_royale/scripts/pool_royale.gd
@@ -25,12 +25,12 @@ func _ready() -> void:
 
 	GameConfigManager.load_config()
 
-	# Command: !fire 90
-	GiftSingleton.add_command("fire", on_viewer_fire, 2, 2)
-	GiftSingleton.add_alias("fire", "f")
+	GiftSingleton.streamer_start.connect(on_streamer_start)
+	GiftSingleton.streamer_wait.connect(on_streamer_wait)
 
-	GiftSingleton.add_command("start", on_streamer_start, 1, 1, GiftSingleton.PermissionFlag.STREAMER)
-	GiftSingleton.add_command("wait", on_streamer_wait, 0, 0, GiftSingleton.PermissionFlag.STREAMER)
+	# Command: !fire 90 100
+	GiftSingleton.add_game_command("fire", on_viewer_fire, 2, 2)
+	GiftSingleton.add_alias("fire", "f")
 
 	SignalBus.transparency_toggled.connect(on_transparency_toggled)
 
@@ -150,14 +150,14 @@ func on_viewer_fire(cmd_info : CommandInfo, arg_arr : PackedStringArray) -> void
 	var power: float = float(arg_arr[1])
 	fire_viewer(cmd_info.sender_data.tags["display-name"], angle, power)
 
-func on_streamer_start(_cmd_info : CommandInfo, arg_arr : PackedStringArray) -> void:
+func on_streamer_start(arg_arr : PackedStringArray) -> void:
 	var countdown_duration: float = default_countdown
 	if not arg_arr.is_empty():
 		if arg_arr[0].is_valid_float():
 			countdown_duration = float(arg_arr[0])
 	countdown.start(countdown_duration)
 
-func on_streamer_wait(_cmd_info : CommandInfo) -> void:
+func on_streamer_wait() -> void:
 	change_state(GAME_STATE.WAITING)
 
 

--- a/scenes/ui/scripts/selection.gd
+++ b/scenes/ui/scripts/selection.gd
@@ -26,6 +26,7 @@ func _ready() -> void:
 	update_checker.get_latest_version()
 	update_checker.release_parsed.connect(on_released_parsed)
 
+	GiftSingleton.remove_game_commands()
 	GiftSingleton.status.connect(on_status_changed)
 
 	# when we connect to late to get the last status, we pull the last status that was emited


### PR DESCRIPTION
closes #79 

- refactor gift singleton
- add `add_game_command` same interface as `add_command`
- add `remove_game_commands`
- the new commands handle registering game commands and unregister game commands in `selection.gd`
- `!start` handled by gift singleton, emits `streamer_start` event
- `!wait` handled by gift singleton, emits `streamer_wait` event
- fixes bug when calling `!start`  with 0 arguments
- `pool_royale` refactored to use new system
- `cannon` refactored to use new system
- `numbermind` refactored to use new system
- `marble_race` is so unfinished, nothing changed
- all new games CAN use the new system but don't have to